### PR TITLE
This adds support for filtering out time-dependent attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class MySnapshotTest extends \Codeception\TestCase\WPTestCase {
 		$postId= $this->factory->post->create();
 		
 		$renderedHtml = $sut->renderHtmlFor($postId);
-      		$driver->setTolerableDifferences([$postId]);
+		$driver->setTolerableDifferences([$postId]);
 		$driver->setTolerableDifferencesPrefixes(['post_', 'post-']);
 		$driver->setTolerableDifferencesPostfixes(['-single', '-another-postfix']);
 		
@@ -47,9 +47,12 @@ class MySnapshotTest extends \Codeception\TestCase\WPTestCase {
 }
 ```
 
-By default the driver will lok for time-dependent fields with an `id`, `name` or `class` from a default list (e.g. `_wpnonce`); you might want to add or modify that list using the `WPHtmlOutputDriver::setTimeDependentKeys` method.  
-On the same note, the driver will look for some attributes when looking to replace the snapshot URL with the current URL; you can modify those using the `WPHtmlOutputDriver::setUrlAttributes` method.  
-Very often WordPress HTML will contain attributes and strings that will inline post IDs, titles and other fields; in general the comparison of the snapshots should not fail because the random post ID used when the snapshot was generated was `23` but it's, in another test run, `89`.  
+By default the driver will lok for time-dependent fields with an `id`, `name` or `class` from a default list (e.g. `_wpnonce`); you might want to add or modify that list using the `WPHtmlOutputDriver::setTimeDependentKeys` method.
+
+On the same note, the driver will look for some attributes when looking to replace the snapshot URL with the current URL; you can modify those using the `WPHtmlOutputDriver::setUrlAttributes` method.
+
+Very often WordPress HTML will contain attributes and strings that will inline post IDs, titles and other fields; in general the comparison of the snapshots should not fail because the random post ID used when the snapshot was generated was `23` but it's, in another test run, `89`.
+
 To avoid that use the `WPHtmlOutputDriver::setTolerableDifferences` method to define what values defined in the current test run should not trigger a failure (see example above); furthermore run-dependent variables could be used to construct `id`, `class`, `data` and other attributes: if you know that the rendered HTML will contain something like this (where `23` is the post ID):
 
 ```html
@@ -64,5 +67,12 @@ You might want to say to the driver that the current post ID is a tolerable diff
 $driver->setTolerableDifferences([$currentPostId]);
 $driver->setTolerableDifferencesPrefixes(['prefix-']);
 $driver->setTolerableDifferencesPostfixes(['-postfix']);
+$this->assertMatchesSnapshot($renderedHtml, $driver);
+```
+
+When HTML attributes contain truly unique or time-dependent values, those attributes can be excluded completely using the `WPHtmlOutputDriver::setTimeDependentAttributes` method.
+
+```php
+$driver->setTimeDependentAttributes(['data-uuid']);
 $this->assertMatchesSnapshot($renderedHtml, $driver);
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ $this->assertMatchesSnapshot($renderedHtml, $driver);
 When HTML attributes contain truly unique or time-dependent values, those attributes can be excluded completely using the `WPHtmlOutputDriver::setTimeDependentAttributes` method.
 
 ```php
-$driver->setTimeDependentAttributes(['data-uuid']);
+$driver->setTimeDependentAttributes(['data-one']);
 $this->assertMatchesSnapshot($renderedHtml, $driver);
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+Add `setTimeDependentAttributes()` method.
+
 ## [1.0.0]
 Initial commit - extracted from the `lucatume/wp-browser` package
 

--- a/tests/WPHtmlOutputDriverTest.php
+++ b/tests/WPHtmlOutputDriverTest.php
@@ -260,4 +260,22 @@ class WPHtmlOutputDriverTest extends TestCase {
 
 		$driver->match($one, $driver->evalCode($two));
 	}
+
+	/**
+	 * It should be able to match a time dependent attribute
+	 *
+	 * @test
+	 */
+	public function should_be_able_to_match_a_time_dependent_attribute() {
+		$template = $this->getSourceFileContents('html-10');
+
+		$driver = new Driver();
+
+		$actual = str_replace(['{{one}}', '{{two}}'], ['23', '89'], $template);
+		$expected = str_replace(['{{one}}', '{{two}}'], ['foo', 'bar'], $template);
+
+		$driver->setTimeDependentAttributes(['data-id']);
+
+		$driver->match($expected, $driver->evalCode($actual));
+	}
 }

--- a/tests/data/snapshots/html-10.php
+++ b/tests/data/snapshots/html-10.php
@@ -1,0 +1,7 @@
+<?php return '
+<div data-id="{{one}}">
+	Some data.
+</div>
+<div data-id="{{two}}">
+ 	Some data.
+</div>';


### PR DESCRIPTION
This modification allows one to set specific HTML attributes for exclusion when performing snapshot matches.

Example:

```php
$this->driver = new WPHtmlOutputDriver( home_url(), 'http://views.dev');
$this->driver->setTimeDependentAttributes( [ 'data-uuid' ] );
```